### PR TITLE
Fix re-encode output path

### DIFF
--- a/src/processor.py
+++ b/src/processor.py
@@ -154,7 +154,9 @@ class Processor:
 
     def _encode(self, video_path, streamer_config):
         try:
-            output_path = ""
+            input_path = os.fspath(video_path)
+            base_path, extension = os.path.splitext(input_path)
+            output_path = f"{base_path}.reencoded{extension}"
             codec = streamer_config.get("encoding", "codec", fallback="libx265")
             crf = streamer_config.get("encoding", "crf", fallback="25")
             preset = streamer_config.get("encoding", "preset", fallback="medium")
@@ -164,7 +166,7 @@ class Processor:
             ffmpeg_cmd = [
                 "ffmpeg",
                 "-i",
-                video_path,
+                input_path,
                 "-c:v",
                 codec,
                 "-crf",

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,72 @@
+import configparser
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+# Add src to path to import processor
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Keep processor imports lightweight for command-construction tests.
+transcription = types.ModuleType("transcription")
+transcription.MIN_DURATION = 999
+transcription.process_video = lambda *args, **kwargs: None
+sys.modules.setdefault("transcription", transcription)
+
+gen_clip = types.ModuleType("gen_clip")
+gen_clip.generate_clips = lambda *args, **kwargs: None
+gen_clip.process_clips = lambda *args, **kwargs: None
+sys.modules.setdefault("gen_clip", gen_clip)
+
+uploader = types.ModuleType("uploader")
+uploader.upload_youtube = lambda *args, **kwargs: None
+sys.modules.setdefault("uploader", uploader)
+
+from processor import Processor
+
+
+def test_encode_writes_to_reencoded_output_path():
+    streamer_config = configparser.ConfigParser()
+    streamer_config["encoding"] = {
+        "codec": "libx264",
+        "crf": "23",
+        "preset": "fast",
+        "log": "warning",
+    }
+    completed = subprocess.CompletedProcess(args=[], returncode=0)
+
+    with patch("processor.run_command", return_value=completed) as run_command:
+        output_path = Processor._encode(object.__new__(Processor), "/tmp/input.mp4", streamer_config)
+
+    assert output_path == "/tmp/input.reencoded.mp4"
+    run_command.assert_called_once_with(
+        [
+            "ffmpeg",
+            "-i",
+            "/tmp/input.mp4",
+            "-c:v",
+            "libx264",
+            "-crf",
+            "23",
+            "-preset",
+            "fast",
+            "-c:a",
+            "copy",
+            "-loglevel",
+            "warning",
+            "/tmp/input.reencoded.mp4",
+        ]
+    )
+
+
+def test_encode_preserves_extensionless_input_names():
+    streamer_config = configparser.ConfigParser()
+    streamer_config["encoding"] = {}
+    completed = subprocess.CompletedProcess(args=[], returncode=0)
+
+    with patch("processor.run_command", return_value=completed):
+        output_path = Processor._encode(object.__new__(Processor), Path("recording"), streamer_config)
+
+    assert output_path == "recording.reencoded"


### PR DESCRIPTION
## Summary
- derive re-encoded output paths from the input video instead of passing an empty string to ffmpeg
- keep extensionless inputs valid by appending `.reencoded`
- add processor tests for the constructed ffmpeg command

Fixes #157

## Testing
- `python3 -m pytest tests/test_processor.py tests/test_utils.py`