### PR TITLE
Fix shorts conversion ffmpeg command

### DIFF
--- a/src/processor.py
+++ b/src/processor.py
@@ -137,14 +137,19 @@ class Processor:
 
         # Shorts video format
         if MIN_DURATION < 130:
+            output_dir = os.path.dirname(output_path)
+            shorts_filename = f"shorts_{os.path.basename(output_path)}"
+            shorts_output_path = os.path.join(output_dir, shorts_filename)
             command = [
                 "ffmpeg",
                 "-i",
                 output_path,
-                '-vf "scale=1080:1920:force_original_aspect_ratio=decrease,pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1"'
+                "-vf",
+                "scale=1080:1920:force_original_aspect_ratio=decrease,"
+                "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
                 "-c",
                 "copy",
-                "s" + output_path,
+                shorts_output_path,
                 "-loglevel",
                 "error",
             ]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+
+# Add src to path to import processor
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Keep processor imports lightweight for command-construction tests.
+transcription = types.ModuleType("transcription")
+transcription.MIN_DURATION = 999
+transcription.process_video = lambda *args, **kwargs: None
+sys.modules.setdefault("transcription", transcription)
+
+gen_clip = types.ModuleType("gen_clip")
+gen_clip.generate_clips = lambda *args, **kwargs: None
+gen_clip.process_clips = lambda *args, **kwargs: None
+sys.modules.setdefault("gen_clip", gen_clip)
+
+uploader = types.ModuleType("uploader")
+uploader.upload_youtube = lambda *args, **kwargs: None
+sys.modules.setdefault("uploader", uploader)
+
+from processor import Processor
+
+
+def test_convert_builds_valid_shorts_ffmpeg_command():
+    processor = object.__new__(Processor)
+
+    with patch("processor.MIN_DURATION", 60), patch("processor.run_command") as run_command:
+        output_path = processor._convert("/tmp/recordings/input.ts")
+
+    assert output_path == "/tmp/recordings/input.mp4"
+    assert run_command.call_args_list[1].args[0] == [
+        "ffmpeg",
+        "-i",
+        "/tmp/recordings/input.mp4",
+        "-vf",
+        "scale=1080:1920:force_original_aspect_ratio=decrease,"
+        "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
+        "-c",
+        "copy",
+        "/tmp/recordings/shorts_input.mp4",
+        "-loglevel",
+        "error",
+    ]


### PR DESCRIPTION
## Summary
- build the shorts ffmpeg invocation as separate arguments instead of embedding shell quoting in one argument
- write shorts output next to the converted clip as `shorts_<filename>` instead of prefixing the whole path
- add a focused unit test for the generated command

Fixes #159.

## Validation
- `python3 -m pytest tests/test_processor.py -q`
