### PR TITLE
Address streamlink quality fallback list (issue #195)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ lib64
 *.ini
 !config.ini
 !default.ini
+!tests/data/*.ini
 
 # Media files
 *.ts 

--- a/default.ini
+++ b/default.ini
@@ -28,6 +28,7 @@ enabled = true
 
 [streamlink]
 # Options: worst, 360p, 480p, 720p, 720p60, 1080p60, best
+# Concatenate like this to provide a fallback list: 1080p60,720p,best
 quality = best
 
 # Options to pass to streamlink (https://streamlink.github.io/cli.html#twitch)

--- a/src/stream_monitor.py
+++ b/src/stream_monitor.py
@@ -78,11 +78,14 @@ class StreamMonitor(threading.Thread):
             logger.error(f"Error running yt-dlp: {e}")
             return None
 
+    def _construct_streamlink_command(self, stream_url, output_path) -> list[str]:
+        quality = self.config["streamlink"]["quality"]
+        return ["streamlink", "-o", output_path, stream_url, quality]
+
     def download_video(self) -> tuple[bool, str]:
         if not self.config:
             return False, ""
 
-        quality = self.config["streamlink"]["quality"]
         current_time = datetime.datetime.now().strftime(self.datetime_format)
         stream_title = self.stream_metadata.get("title", "")
         stream_id = self.stream_metadata.get("id", current_time)
@@ -107,7 +110,7 @@ class StreamMonitor(threading.Thread):
                     "Failed to get direct URL from yt-dlp, falling back to original URL"
                 )
 
-        command = ["streamlink", "-o", output_path, stream_url, quality]
+        command = self._construct_streamlink_command(stream_url, output_path)
 
         if self.config.has_option("streamlink", "flags"):
             flags = self.config.get("streamlink", "flags").strip(",").split(",")

--- a/src/stream_monitor.py
+++ b/src/stream_monitor.py
@@ -78,22 +78,8 @@ class StreamMonitor(threading.Thread):
             logger.error(f"Error running yt-dlp: {e}")
             return None
 
-    def _construct_streamlink_command(self, stream_url, output_path) -> list[str]:
+    def _construct_streamlink_command(self, output_path) -> list[str]:
         quality = self.config["streamlink"]["quality"]
-        return ["streamlink", "-o", output_path, stream_url, quality]
-
-    def download_video(self) -> tuple[bool, str]:
-        if not self.config:
-            return False, ""
-
-        current_time = datetime.datetime.now().strftime(self.datetime_format)
-        stream_title = self.stream_metadata.get("title", "")
-        stream_id = self.stream_metadata.get("id", current_time)
-
-        output_path = f"recordings/{self.streamer_name}/{stream_id}/{stream_title}-{self.streamer_name}-{current_time}.ts"
-
-        output_dir = os.path.dirname(output_path)
-        os.makedirs(output_dir, exist_ok=True)
 
         # For YouTube, use yt-dlp to get the direct stream URL first
         # This is a workaround for YouTube Live streams that stopped working with streamlink directly
@@ -109,6 +95,21 @@ class StreamMonitor(threading.Thread):
                 logger.warning(
                     "Failed to get direct URL from yt-dlp, falling back to original URL"
                 )
+
+        return ["streamlink", "-o", output_path, stream_url, quality]
+
+    def download_video(self) -> tuple[bool, str]:
+        if not self.config:
+            return False, ""
+
+        current_time = datetime.datetime.now().strftime(self.datetime_format)
+        stream_title = self.stream_metadata.get("title", "")
+        stream_id = self.stream_metadata.get("id", current_time)
+
+        output_path = f"recordings/{self.streamer_name}/{stream_id}/{stream_title}-{self.streamer_name}-{current_time}.ts"
+
+        output_dir = os.path.dirname(output_path)
+        os.makedirs(output_dir, exist_ok=True)
 
         command = self._construct_streamlink_command(stream_url, output_path)
 

--- a/tests/data/quality_fallback.ini
+++ b/tests/data/quality_fallback.ini
@@ -1,0 +1,2 @@
+[streamlink]
+quality = 1080p60,720p,best

--- a/tests/data/quality_non_fallback.ini
+++ b/tests/data/quality_non_fallback.ini
@@ -1,0 +1,2 @@
+[streamlink]
+quality = best

--- a/tests/test_stream_monitor.py
+++ b/tests/test_stream_monitor.py
@@ -18,28 +18,32 @@ class TestStreamMonitor:
         """Test streamlink command is constructed correctly from config"""
         with patch.object(StreamMonitor, "_load_configuration", return_value=True):
             monitor = StreamMonitor("streamername")
+            monitor.stream_source_url = "twitch.tv/streamername"
             monitor.config = configparser.ConfigParser()
             # Populate config directly
             monitor.config.read_dict({"streamlink": {"quality": "1080p60,720p,best"}})
-            command = monitor._construct_streamlink_command("stream.url", "output/path")
+            command = monitor._construct_streamlink_command("output/path")
             assert command[-1] == "1080p60,720p,best"
+
 
     def test_quality_config_with_fallbacks(self):
         """Test quality fallback is read correctly from config file"""
         with patch.object(StreamMonitor, "_load_configuration", return_value=True):
             monitor = StreamMonitor("streamername")
+            monitor.stream_source_url = "twitch.tv/streamername"
             # Load stubbed config file
             monitor.config = load_config("tests/data/quality_fallback")
 
-            command = monitor._construct_streamlink_command("stream.url", "output/path")
+            command = monitor._construct_streamlink_command("output/path")
             assert command[-1] == "1080p60,720p,best"
 
     def test_quality_config_with_single_value(self):
         """Test streamlink single-value quality is read correctly from config file"""
         with patch.object(StreamMonitor, "_load_configuration", return_value=True):
             monitor = StreamMonitor("streamername")
+            monitor.stream_source_url = "twitch.tv/streamername"
             # Load stubbed config file
             monitor.config = load_config("tests/data/quality_non_fallback")
 
-            command = monitor._construct_streamlink_command("stream.url", "output/path")
+            command = monitor._construct_streamlink_command("output/path")
             assert command[-1] == "best"

--- a/tests/test_stream_monitor.py
+++ b/tests/test_stream_monitor.py
@@ -14,36 +14,34 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 class TestStreamMonitor:
     """Test cases for StreamMonitor class"""
 
-    def test_streamlink_command_construction(self):
+    @pytest.fixture
+    def monitor(self):
+        # Patch _load_configuration to control config loading
+        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
+            monitor = StreamMonitor("streamername")
+        monitor.stream_source_url = "twitch.tv/streamername"
+        return monitor
+
+    def test_streamlink_command_construction(self, monitor):
         """Test streamlink command is constructed correctly from config"""
-        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
-            monitor = StreamMonitor("streamername")
-            monitor.stream_source_url = "twitch.tv/streamername"
-            monitor.config = configparser.ConfigParser()
-            # Populate config directly
-            monitor.config.read_dict({"streamlink": {"quality": "1080p60,720p,best"}})
-            command = monitor._construct_streamlink_command("output/path")
-            assert command[-1] == "1080p60,720p,best"
+        monitor.config = configparser.ConfigParser()
+        # Populate config directly
+        monitor.config.read_dict({"streamlink": {"quality": "1080p60,720p,best"}})
+        command = monitor._construct_streamlink_command("output/path")
+        assert command[-1] == "1080p60,720p,best"
 
-
-    def test_quality_config_with_fallbacks(self):
+    def test_quality_config_with_fallbacks(self, monitor):
         """Test quality fallback is read correctly from config file"""
-        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
-            monitor = StreamMonitor("streamername")
-            monitor.stream_source_url = "twitch.tv/streamername"
-            # Load stubbed config file
-            monitor.config = load_config("tests/data/quality_fallback")
+        # Load stubbed config file
+        monitor.config = load_config("tests/data/quality_fallback")
 
-            command = monitor._construct_streamlink_command("output/path")
-            assert command[-1] == "1080p60,720p,best"
+        command = monitor._construct_streamlink_command("output/path")
+        assert command[-1] == "1080p60,720p,best"
 
-    def test_quality_config_with_single_value(self):
+    def test_quality_config_with_single_value(self, monitor):
         """Test streamlink single-value quality is read correctly from config file"""
-        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
-            monitor = StreamMonitor("streamername")
-            monitor.stream_source_url = "twitch.tv/streamername"
-            # Load stubbed config file
-            monitor.config = load_config("tests/data/quality_non_fallback")
+        # Load stubbed config file
+        monitor.config = load_config("tests/data/quality_non_fallback")
 
-            command = monitor._construct_streamlink_command("output/path")
-            assert command[-1] == "best"
+        command = monitor._construct_streamlink_command("output/path")
+        assert command[-1] == "best"

--- a/tests/test_stream_monitor.py
+++ b/tests/test_stream_monitor.py
@@ -1,0 +1,45 @@
+import configparser
+import os
+import pytest
+import sys
+from stream_monitor import StreamMonitor
+from unittest.mock import patch
+
+from utils import load_config
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+class TestStreamMonitor:
+    """Test cases for StreamMonitor class"""
+
+    def test_streamlink_command_construction(self):
+        """Test streamlink command is constructed correctly from config"""
+        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
+            monitor = StreamMonitor("streamername")
+            monitor.config = configparser.ConfigParser()
+            # Populate config directly
+            monitor.config.read_dict({"streamlink": {"quality": "1080p60,720p,best"}})
+            command = monitor._construct_streamlink_command("stream.url", "output/path")
+            assert command[-1] == "1080p60,720p,best"
+
+    def test_quality_config_with_fallbacks(self):
+        """Test quality fallback is read correctly from config file"""
+        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
+            monitor = StreamMonitor("streamername")
+            # Load stubbed config file
+            monitor.config = load_config("tests/data/quality_fallback")
+
+            command = monitor._construct_streamlink_command("stream.url", "output/path")
+            assert command[-1] == "1080p60,720p,best"
+
+    def test_quality_config_with_single_value(self):
+        """Test streamlink single-value quality is read correctly from config file"""
+        with patch.object(StreamMonitor, "_load_configuration", return_value=True):
+            monitor = StreamMonitor("streamername")
+            # Load stubbed config file
+            monitor.config = load_config("tests/data/quality_non_fallback")
+
+            command = monitor._construct_streamlink_command("stream.url", "output/path")
+            assert command[-1] == "best"


### PR DESCRIPTION
Extracts `StreamMonitor`'s streamlink command construction to a method for unit testing and adds unit tests for the functionality.

Note: The new feature isn't mentioned in the README, as I feel it's sufficiently documented in `default.ini`.