### PR TITLE
fix: align minimum Python version with pyproject.toml (#188)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -48,8 +48,8 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    if sys.version_info < (3, 9):
-        print("Error: Python 3.9 or higher is required")
+    if sys.version_info < (3, 10):
+        print("Error: Python 3.10 or higher is required")
         print("Current Python version: " + sys.version)
         sys.exit(1)
     sys.exit(main())


### PR DESCRIPTION
## Summary

The runtime Python version check in  was checking for Python 3.9, but  specifies . This inconsistency could allow users on Python 3.9 to install the package (via pip) but then hit a confusing runtime error.

### Changes
- : Changed version check from  to  and updated the error message to match.

Fixes #188