### PR TITLE
Faster live stream check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # Open router api key
 OPEN_ROUTER_KEY=
+
+# Twitch API
+TWITCH_API_OAUTH_TOKEN=
+TWITCH_APP_CLIENT_ID=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ test = [
     "pytest",
     "loguru",
     "dotenv",
+    "responses",
 ]
 
 [project.urls]

--- a/src/settings.py
+++ b/src/settings.py
@@ -7,6 +7,9 @@ from logger import logger
 load_dotenv()
 
 API_KEY = os.getenv("OPEN_ROUTER_KEY")
+TWITCH_API_OAUTH_TOKEN = os.getenv("TWITCH_API_OAUTH_TOKEN")
+TWITCH_APP_CLIENT_ID = os.getenv("TWITCH_APP_CLIENT_ID")
+
 config: configparser.ConfigParser = load_config("config")
 
 CLIPCEPTION_ENABLED = config.get("clipception", "enabled").lower() == "true"
@@ -18,3 +21,17 @@ if not API_KEY:
     )
     logger.info("You can set it with: export OPEN_ROUTER_KEY='your_key'")
     CLIPCEPTION_ENABLED = False
+
+
+# Check for Twitch API requirements
+if not TWITCH_API_OAUTH_TOKEN or not TWITCH_APP_CLIENT_ID:
+    logger.warning(
+        "Warning: TWITCH_API_OAUTH_TOKEN and TWITCH_APP_CLIENT_ID "
+        "environment variables are not both set. "
+        "Set them to increase speed when checking twitch stream statuses."
+    )
+    logger.info(
+        "You can set them with: "
+        "export TWITCH_API_OAUTH_TOKEN='your_token' "
+        "&& export TWITCH_APP_CLIENT_ID='your_client_id'"
+    )

--- a/src/utils.py
+++ b/src/utils.py
@@ -59,11 +59,11 @@ def determine_source(stream_source: StreamPlatform, streamer_name: str) -> str |
     streamer_name = streamer_name.strip().lower()
 
     sources: dict[StreamPlatform, str] = {
-        StreamPlatform.TWITCH: f"https://twitch.tv/{streamer_name}",
-        StreamPlatform.KICK: f"https://kick.com/{streamer_name}",
-        StreamPlatform.YOUTUBE: f"https://youtube.com/@{streamer_name}/live",
-        StreamPlatform.RUMBLE: f"https://rumble.com/user/{streamer_name}",
-        StreamPlatform.DLIVE: f"https://dlive.tv/{streamer_name}",
+        StreamPlatform.TWITCH: f"twitch.tv/{streamer_name}",
+        StreamPlatform.KICK: f"kick.com/{streamer_name}",
+        StreamPlatform.YOUTUBE: f"youtube.com/@{streamer_name}/live",
+        StreamPlatform.RUMBLE: f"rumble.com/user/{streamer_name}",
+        StreamPlatform.DLIVE: f"dlive.tv/{streamer_name}",
     }
     return sources.get(stream_source)
 
@@ -75,6 +75,7 @@ def check_stream_live(url: str) -> bool:
     Uses different methods for each service, and streamlink as a fallback.
     """
     # TODO: proper from-url-to-platform
+    url = "https://" + url
     s = "youtube" if "youtube" in url else "twitch"
     platform = StreamPlatform.from_string(s)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -104,6 +104,17 @@ def is_twitch_channel_live(url: str) -> bool:
         return False
 
 
+def is_youtube_channel_live(url: str) -> bool:
+    r = requests.get(url)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    live_indicator = "/watch?v="
+    link_element = soup.find("link", rel="canonical")
+
+    # Confirm whether body contains `<link ... href=".../watch?v=...">`
+    return link_element and (live_indicator in link_element["href"])
+
+
 def check_stream_live(url: str) -> bool:
     """
     Check if given stream is live
@@ -121,15 +132,8 @@ def check_stream_live(url: str) -> bool:
     elif platform == StreamPlatform.KICK:
         pass
     elif platform == StreamPlatform.YOUTUBE:
-        r = requests.get(url)
-        soup = BeautifulSoup(r.text, "html.parser")
-        live_indicator = "/watch?v="
-        link_element = soup.find("link", rel="canonical")
+        return is_youtube_channel_live(url)
 
-        if link_element and live_indicator in link_element["href"]:
-            return True
-        else:
-            return False
     elif platform == StreamPlatform.RUMBLE:
         pass
     elif platform == StreamPlatform.DLIVE:

--- a/src/utils.py
+++ b/src/utils.py
@@ -68,6 +68,42 @@ def determine_source(stream_source: StreamPlatform, streamer_name: str) -> str |
     return sources.get(stream_source)
 
 
+def is_twitch_channel_live(url: str) -> bool:
+    # Last-minute import to avoid circular imports
+    from settings import TWITCH_API_OAUTH_TOKEN, TWITCH_APP_CLIENT_ID
+
+    if TWITCH_API_OAUTH_TOKEN and TWITCH_APP_CLIENT_ID:
+        # Prepare headers and query
+        streamer_login = url.split("/")[-1]
+        payload = {"user_login": streamer_login}
+        headers = {
+            "Authorization": "Bearer " + TWITCH_API_OAUTH_TOKEN,
+            "Client-Id": TWITCH_APP_CLIENT_ID,
+        }
+        # Make call to "streams"-endpoint
+        # https://dev.twitch.tv/docs/api/reference#get-streams
+        r = requests.get(
+            "https://api.twitch.tv/helix/streams", params=payload, headers=headers
+        )
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if r.status_code == 401:
+                raise requests.exceptions.HTTPError(
+                    "Invalid or expired Twitch API OAuth token."
+                ) from e
+            raise
+
+        # If the data shows any streams present (since we're querying
+        # for only one streamer), that streamer is necessarily live
+        body: dict = r.json()
+        return bool(body["data"])
+
+    else:
+        # If no auth see GraphQL useLive
+        return False
+
+
 def check_stream_live(url: str) -> bool:
     """
     Check if given stream is live
@@ -80,7 +116,8 @@ def check_stream_live(url: str) -> bool:
     platform = StreamPlatform.from_string(s)
 
     if platform == StreamPlatform.TWITCH:
-        pass
+        return is_twitch_channel_live(url)
+
     elif platform == StreamPlatform.KICK:
         pass
     elif platform == StreamPlatform.YOUTUBE:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,8 @@
 import os
+import requests
 import sys
 import subprocess
+from bs4 import BeautifulSoup
 from enum import Enum
 from logger import logger
 from pathlib import Path
@@ -57,16 +59,44 @@ def determine_source(stream_source: StreamPlatform, streamer_name: str) -> str |
     streamer_name = streamer_name.strip().lower()
 
     sources: dict[StreamPlatform, str] = {
-        StreamPlatform.TWITCH: f"twitch.tv/{streamer_name}",
-        StreamPlatform.KICK: f"kick.com/{streamer_name}",
-        StreamPlatform.YOUTUBE: f"youtube.com/@{streamer_name}/live",
-        StreamPlatform.RUMBLE: f"rumble.com/user/{streamer_name}",
-        StreamPlatform.DLIVE: f"dlive.tv/{streamer_name}",
+        StreamPlatform.TWITCH: f"https://twitch.tv/{streamer_name}",
+        StreamPlatform.KICK: f"https://kick.com/{streamer_name}",
+        StreamPlatform.YOUTUBE: f"https://youtube.com/@{streamer_name}/live",
+        StreamPlatform.RUMBLE: f"https://rumble.com/user/{streamer_name}",
+        StreamPlatform.DLIVE: f"https://dlive.tv/{streamer_name}",
     }
     return sources.get(stream_source)
 
 
 def check_stream_live(url: str) -> bool:
+    """
+    Check if given stream is live
+
+    Uses different methods for each service, and streamlink as a fallback.
+    """
+    # TODO: proper from-url-to-platform
+    s = "youtube" if "youtube" in url else "twitch"
+    platform = StreamPlatform.from_string(s)
+
+    if platform == StreamPlatform.TWITCH:
+        pass
+    elif platform == StreamPlatform.KICK:
+        pass
+    elif platform == StreamPlatform.YOUTUBE:
+        r = requests.get(url)
+        soup = BeautifulSoup(r.text, "html.parser")
+        live_indicator = "/watch?v="
+        link_element = soup.find("link", rel="canonical")
+
+        if link_element and live_indicator in link_element["href"]:
+            return True
+        else:
+            return False
+    elif platform == StreamPlatform.RUMBLE:
+        pass
+    elif platform == StreamPlatform.DLIVE:
+        pass
+
     # TODO this takes many seconds, find a faster method
     result = run_command(["streamlink", url])
     return result.returncode == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,11 +157,11 @@ class TestStreamIsLive:
 
     @responses.activate
     def test_youtube_is_live(self):
-        url = "https://youtube.com/@channelname/live"
+        url = "youtube.com/@channelname/live"
         # Intercept GET request to provide youtube-live-like body
         responses.add(
             responses.GET,
-            url,
+            "https://" + url,
             body="<html>"
             r'<link href="https://www.youtube.com/watch?v=abcd1234" rel="canonical"/>'
             "</html>",
@@ -170,12 +170,12 @@ class TestStreamIsLive:
 
     @responses.activate
     def test_youtube_is_not_live(self):
-        url = "https://youtube.com/@channelname/live"
+        url = "youtube.com/@channelname/live"
         # Intercept GET request to provide youtube-channel-like body
         # (as in what you're redirected to in case a channel is not live)
         responses.add(
             responses.GET,
-            url,
+            "https://" + url,
             body="<html>"
             r'<link href="https://www.youtube.com/channel/abcd1234" rel="canonical"/>'
             "</html>",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -183,24 +183,22 @@ class TestStreamIsLive:
         )
         assert not check_stream_live(url)
 
-    @pytest.mark.twitch_api
     @responses.activate
     def test_twitch_is_live(self):
         url = "twitch.tv/streamername"
+        api_endpoint = "https://api.twitch.tv/helix/streams"
         # Intercept GET request with an expected response for a live stream
         responses.add(
             responses.GET,
-            "https://" + url,
+            api_endpoint,
             json={"data": [{"user_login": "streamername"}], "pagination": {}},
         )
         assert check_stream_live(url)
 
-    @pytest.mark.twitch_api
     @responses.activate
     def test_twitch_is_not_live(self):
         url = "twitch.tv/streamername"
+        api_endpoint = "https://api.twitch.tv/helix/streams"
         # Intercept GET request with an expected response for a non-live channel
-        responses.add(
-            responses.GET, "https://" + url, json={"data": [], "pagination": {}}
-        )
+        responses.add(responses.GET, api_endpoint, json={"data": [], "pagination": {}})
         assert not check_stream_live(url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import responses
 import sys
 import tempfile
@@ -179,5 +180,27 @@ class TestStreamIsLive:
             body="<html>"
             r'<link href="https://www.youtube.com/channel/abcd1234" rel="canonical"/>'
             "</html>",
+        )
+        assert not check_stream_live(url)
+
+    @pytest.mark.twitch_api
+    @responses.activate
+    def test_twitch_is_live(self):
+        url = "twitch.tv/streamername"
+        # Intercept GET request with an expected response for a live stream
+        responses.add(
+            responses.GET,
+            "https://" + url,
+            json={"data": [{"user_login": "streamername"}], "pagination": {}},
+        )
+        assert check_stream_live(url)
+
+    @pytest.mark.twitch_api
+    @responses.activate
+    def test_twitch_is_not_live(self):
+        url = "twitch.tv/streamername"
+        # Intercept GET request with an expected response for a non-live channel
+        responses.add(
+            responses.GET, "https://" + url, json={"data": [], "pagination": {}}
         )
         assert not check_stream_live(url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import responses
 import sys
 import tempfile
 from unittest.mock import patch
@@ -6,7 +7,14 @@ from unittest.mock import patch
 # Add src to path to import utils
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from utils import determine_source, is_docker, get_size, load_config, StreamPlatform
+from utils import (
+    check_stream_live,
+    determine_source,
+    get_size,
+    is_docker,
+    load_config,
+    StreamPlatform,
+)
 
 
 class TestDetermineSource:
@@ -142,3 +150,34 @@ class TestLoadConfig:
         config = load_config("default")
         if config is not None:
             assert isinstance(config, configparser.ConfigParser)
+
+
+class TestStreamIsLive:
+    """Test cases for check_stream_live function"""
+
+    @responses.activate
+    def test_youtube_is_live(self):
+        url = "https://youtube.com/@channelname/live"
+        # Intercept GET request to provide youtube-live-like body
+        responses.add(
+            responses.GET,
+            url,
+            body="<html>"
+            r'<link href="https://www.youtube.com/watch?v=abcd1234" rel="canonical"/>'
+            "</html>",
+        )
+        assert check_stream_live(url)
+
+    @responses.activate
+    def test_youtube_is_not_live(self):
+        url = "https://youtube.com/@channelname/live"
+        # Intercept GET request to provide youtube-channel-like body
+        # (as in what you're redirected to in case a channel is not live)
+        responses.add(
+            responses.GET,
+            url,
+            body="<html>"
+            r'<link href="https://www.youtube.com/channel/abcd1234" rel="canonical"/>'
+            "</html>",
+        )
+        assert not check_stream_live(url)


### PR DESCRIPTION
A faster implementation for checking a Youtube stream is live, addressing only part of issue #186 

Includes some changes which might not be wanted, so I'm requesting feedback, especially from @0jc1 :
- The new unit tests rely on the `responses` package, this can be changed, but `responses` seems to be the best way to test for `requests`
- The URL templates in `src/utils.py.determine_source` are changed to specify `https://`, to play better with `requests` and `responses`. The only place `determine_source` is used is in `StreamMonitor._load_configuration`. The change seems to not break anything.