### PR TITLE
fix: create shorts variants per generated clip

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -15,6 +15,9 @@ enabled = true
 # Duration of clips in seconds
 clip_duration = 60
 
+# Generate a 9:16 shorts variant for each extracted clip
+shorts_format = false
+
 # Default number of clips to generate per video
 num_clips = 10
 

--- a/default.ini
+++ b/default.ini
@@ -26,6 +26,9 @@ save_on_fail = false
 # Enable this to auto generate viral clips
 enabled = true
 
+# Generate a 9:16 shorts variant for each extracted clip
+shorts_format = false
+
 [streamlink]
 # Options: worst, 360p, 480p, 720p, 720p60, 1080p60, best
 # Comma-separated fallback list is supported (e.g: quality = 1080p60,720p,best)

--- a/src/gen_clip.py
+++ b/src/gen_clip.py
@@ -209,7 +209,31 @@ def generate_clips(
         logger.exception("Error generating clips")
 
 
-def extract_clip(input_file, output_dir, clip_data):
+def _shorts_output_path(output_file):
+    base_path, _ = os.path.splitext(output_file)
+    return f"{base_path}_shorts.mp4"
+
+
+def _convert_clip_to_shorts(input_file):
+    output_file = _shorts_output_path(input_file)
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_file,
+        "-vf",
+        "scale=1080:1920:force_original_aspect_ratio=decrease,"
+        "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        output_file,
+    ]
+    return run_command(cmd), output_file
+
+
+def extract_clip(input_file, output_dir, clip_data, shorts_format=False):
     """Extract a single clip using ffmpeg ."""
     try:
         # Sanitize clip name for filename
@@ -246,6 +270,14 @@ def extract_clip(input_file, output_dir, clip_data):
         # Check if ffmpeg succeeded
         if result.returncode == 0 and os.path.exists(output_file):
             logger.info(f"Clip extracted: {output_file}")
+            if shorts_format:
+                shorts_result, shorts_output = _convert_clip_to_shorts(output_file)
+                if shorts_result.returncode == 0 and os.path.exists(shorts_output):
+                    logger.info(f"Shorts clip extracted: {shorts_output}")
+                else:
+                    logger.error(
+                        f"Shorts conversion failed with code {shorts_result.returncode}"
+                    )
             return True, output_file
         else:
             logger.error(f"FFmpeg failed with code {result.returncode}")
@@ -256,7 +288,7 @@ def extract_clip(input_file, output_dir, clip_data):
         return False, str(e)
 
 
-def process_clips(input_file, output_dir, json_file, min_score=0):
+def process_clips(input_file, output_dir, json_file, min_score=0, shorts_format=False):
     """Process all clips from the JSON file that meet the minimum score requirement"""
 
     # Create output directory if it doesn't exist
@@ -273,7 +305,9 @@ def process_clips(input_file, output_dir, json_file, min_score=0):
 
     for clip in data["top_clips"]:
         if clip["score"] >= min_score:
-            success, result = extract_clip(input_file, output_dir, clip)
+            success, result = extract_clip(
+                input_file, output_dir, clip, shorts_format=shorts_format
+            )
             if success:
                 successful_clips.append((clip["name"], result))
             else:

--- a/src/processor.py
+++ b/src/processor.py
@@ -7,7 +7,7 @@ from utils import run_command
 from uploader import upload_youtube
 
 # clipception
-from transcription import process_video, MIN_DURATION
+from transcription import process_video
 from gen_clip import generate_clips, process_clips
 
 
@@ -135,26 +135,6 @@ class Processor:
         ]
         run_command(command)
 
-        # Shorts video format
-        if MIN_DURATION < 130:
-            output_dir = os.path.dirname(output_path)
-            shorts_filename = f"shorts_{os.path.basename(output_path)}"
-            shorts_output_path = os.path.join(output_dir, shorts_filename)
-            command = [
-                "ffmpeg",
-                "-i",
-                output_path,
-                "-vf",
-                "scale=1080:1920:force_original_aspect_ratio=decrease,"
-                "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
-                "-c",
-                "copy",
-                shorts_output_path,
-                "-loglevel",
-                "error",
-            ]
-            run_command(command)
-
         return output_path
 
     def _encode(self, video_path, streamer_config):
@@ -204,6 +184,9 @@ class Processor:
         """Process a video file with clipception to generate clips."""
         try:
             num_clips = config.getint("clipception", "num_clips", fallback=10)
+            shorts_format = config.getboolean(
+                "clipception", "shorts_format", fallback=False
+            )
             min_score = 0  # Default minimum score threshold
             chunk_size = 10
 
@@ -262,7 +245,11 @@ class Processor:
 
             try:
                 process_clips(
-                    video_path, clips_output_dir, output_file, min_score=min_score
+                    video_path,
+                    clips_output_dir,
+                    output_file,
+                    min_score=min_score,
+                    shorts_format=shorts_format,
                 )
             except Exception:
                 logger.exception("Error during clip extraction")

--- a/tests/test_gen_clip.py
+++ b/tests/test_gen_clip.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.modules.pop("gen_clip", None)
+
+from gen_clip import extract_clip  # noqa: E402
+
+
+def test_extract_clip_can_create_shorts_variant(tmp_path):
+    completed = subprocess.CompletedProcess(args=[], returncode=0)
+    clip_data = {"name": "Great clip", "start": 10, "end": 20}
+
+    with (
+        patch("gen_clip.run_command", return_value=completed) as run_command,
+        patch("gen_clip.os.path.exists", return_value=True),
+    ):
+        success, output_file = extract_clip(
+            "vod.mp4", tmp_path, clip_data, shorts_format=True
+        )
+
+    assert success is True
+    assert output_file == str(Path(tmp_path) / "Great clip.mp4")
+    assert run_command.call_args_list[0].args[0] == [
+        "ffmpeg",
+        "-y",
+        "-ss",
+        "10",
+        "-to",
+        "20",
+        "-i",
+        "vod.mp4",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        str(Path(tmp_path) / "Great clip.mp4"),
+    ]
+    assert run_command.call_args_list[1].args[0] == [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(Path(tmp_path) / "Great clip.mp4"),
+        "-vf",
+        "scale=1080:1920:force_original_aspect_ratio=decrease,"
+        "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        str(Path(tmp_path) / "Great clip_shorts.mp4"),
+    ]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -4,9 +4,6 @@ import subprocess
 import sys
 import types
 from pathlib import Path
-import os
-import sys
-import types
 from unittest.mock import patch
 
 # Add src to path to import processor
@@ -27,7 +24,7 @@ uploader = types.ModuleType("uploader")
 uploader.upload_youtube = lambda *args, **kwargs: None
 sys.modules.setdefault("uploader", uploader)
 
-from processor import Processor
+from processor import Processor  # noqa: E402
 
 
 def test_encode_writes_to_reencoded_output_path():
@@ -79,26 +76,44 @@ def test_encode_preserves_extensionless_input_names():
     assert output_path == "recording.reencoded"
 
 
-def test_convert_builds_valid_shorts_ffmpeg_command():
+def test_convert_does_not_build_shorts_from_full_vod():
     processor = object.__new__(Processor)
 
-    with (
-        patch("processor.MIN_DURATION", 60),
-        patch("processor.run_command") as run_command,
-    ):
+    with patch("processor.run_command") as run_command:
         output_path = processor._convert("/tmp/recordings/input.ts")
 
     assert output_path == "/tmp/recordings/input.mp4"
-    assert run_command.call_args_list[1].args[0] == [
-        "ffmpeg",
-        "-i",
+    run_command.assert_called_once_with(
+        [
+            "ffmpeg",
+            "-i",
+            "/tmp/recordings/input.ts",
+            "-c",
+            "copy",
+            "/tmp/recordings/input.mp4",
+            "-loglevel",
+            "error",
+        ]
+    )
+
+
+def test_process_single_file_passes_shorts_format_to_clips():
+    processor = object.__new__(Processor)
+
+    with (
+        patch("processor.os.path.exists", return_value=True),
+        patch("processor.process_video"),
+        patch("processor.generate_clips"),
+        patch("processor.process_clips") as process_clips,
+        patch("processor.config.getint", return_value=10),
+        patch("processor.config.getboolean", return_value=True),
+    ):
+        processor._process_single_file("/tmp/recordings/input.mp4", "streamer")
+
+    process_clips.assert_called_once_with(
         "/tmp/recordings/input.mp4",
-        "-vf",
-        "scale=1080:1920:force_original_aspect_ratio=decrease,"
-        "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
-        "-c",
-        "copy",
-        "/tmp/recordings/shorts_input.mp4",
-        "-loglevel",
-        "error",
-    ]
+        "/tmp/recordings/clips",
+        "/tmp/recordings/top_clips_one.json",
+        min_score=0,
+        shorts_format=True,
+    )


### PR DESCRIPTION
## Summary
- remove shorts conversion from full VOD `_convert()`
- add `clipception.shorts_format = false` as an opt-in setting
- pass `shorts_format` into clip extraction and create `<clip>_shorts.mp4` beside each generated clip when enabled
- add regression coverage for full-VOD conversion, config propagation, and per-clip shorts ffmpeg command

Fixes #217.

## Tests
- uv run --with pytest --with loguru --with python-dotenv pytest tests/test_processor.py tests/test_gen_clip.py -q
- uv run --with black black --check src/processor.py src/gen_clip.py tests/test_processor.py tests/test_gen_clip.py
- uv run --with ruff ruff check src/processor.py src/gen_clip.py tests/test_processor.py tests/test_gen_clip.py
- git diff --check
