### PR TITLE
test: cover core processing modules

### DIFF
--- a/tests/test_gen_clip.py
+++ b/tests/test_gen_clip.py
@@ -1,13 +1,35 @@
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 sys.modules.pop("gen_clip", None)
 
-from gen_clip import extract_clip  # noqa: E402
+from gen_clip import (  # noqa: E402
+    _convert_clip_to_shorts,
+    _shorts_output_path,
+    chunk_list,
+    extract_clip,
+    load_clips,
+    parse_clip_data,
+    process_chunk,
+)
+
+
+def valid_clip():
+    return {
+        "name": "Great clip",
+        "start": 10,
+        "end": 20,
+        "score": 9,
+        "factors": "engaging",
+        "platforms": "shorts",
+    }
 
 
 def test_extract_clip_can_create_shorts_variant(tmp_path):
@@ -53,3 +75,175 @@ def test_extract_clip_can_create_shorts_variant(tmp_path):
         "aac",
         str(Path(tmp_path) / "Great clip_shorts.mp4"),
     ]
+
+
+@pytest.mark.parametrize(
+    ("values", "chunk_size", "expected"),
+    [
+        ([], 3, []),
+        ([1, 2, 3, 4], 2, [[1, 2], [3, 4]]),
+        ([1, 2, 3, 4, 5], 2, [[1, 2], [3, 4], [5]]),
+        ([1, 2], 5, [[1, 2]]),
+        ([1, 2, 3], 1, [[1], [2], [3]]),
+    ],
+)
+def test_chunk_list(values, chunk_size, expected):
+    assert chunk_list(values, chunk_size) == expected
+
+
+def test_chunk_list_rejects_zero_chunk_size():
+    with pytest.raises(ValueError):
+        chunk_list([1, 2, 3], 0)
+
+
+def test_load_clips_reads_json_payload(tmp_path):
+    clips = [valid_clip()]
+    clips_path = tmp_path / "clips.json"
+    clips_path.write_text(json.dumps(clips))
+
+    assert load_clips(str(clips_path)) == clips
+
+
+def test_load_clips_reports_missing_file(tmp_path):
+    missing_path = tmp_path / "missing.json"
+
+    with pytest.raises(FileNotFoundError, match="Clips file not found"):
+        load_clips(str(missing_path))
+
+
+def test_load_clips_reports_invalid_json(tmp_path):
+    clips_path = tmp_path / "clips.json"
+    clips_path.write_text("not-json")
+
+    with pytest.raises(ValueError, match="Invalid JSON format"):
+        load_clips(str(clips_path))
+
+
+def test_process_chunk_parses_ranked_results():
+    parsed_clips = [valid_clip()]
+
+    with (
+        patch("gen_clip.rank_clips_chunk", return_value="ranked") as rank,
+        patch("gen_clip.parse_clip_data", return_value=parsed_clips) as parse,
+    ):
+        result = process_chunk(([{"text": "clip"}], 3))
+
+    assert result == parsed_clips
+    rank.assert_called_once_with([{"text": "clip"}])
+    parse.assert_called_once_with("ranked")
+
+
+def test_process_chunk_returns_empty_when_ranking_returns_nothing():
+    with patch("gen_clip.rank_clips_chunk", return_value=""):
+        assert process_chunk(([{"text": "clip"}], 3)) == []
+
+
+def test_process_chunk_returns_empty_when_ranking_raises():
+    with patch("gen_clip.rank_clips_chunk", side_effect=RuntimeError("offline")):
+        assert process_chunk(([{"text": "clip"}], 3)) == []
+
+
+@pytest.mark.parametrize("input_string", [None, ""])
+def test_parse_clip_data_returns_empty_for_empty_input(input_string):
+    assert parse_clip_data(input_string) == []
+
+
+def test_parse_clip_data_accepts_plain_json():
+    clip = valid_clip()
+
+    assert parse_clip_data(json.dumps({"clips": [clip]})) == [clip]
+
+
+def test_parse_clip_data_accepts_markdown_fenced_json():
+    clip = valid_clip()
+    payload = f"```json\n{json.dumps({'clips': [clip]})}\n```"
+
+    assert parse_clip_data(payload) == [clip]
+
+
+@pytest.mark.parametrize(
+    "missing_key", ["name", "start", "end", "score", "factors", "platforms"]
+)
+def test_parse_clip_data_filters_clips_missing_required_keys(missing_key):
+    complete_clip = valid_clip()
+    incomplete_clip = valid_clip()
+    incomplete_clip.pop(missing_key)
+    payload = json.dumps({"clips": [incomplete_clip, complete_clip]})
+
+    assert parse_clip_data(payload) == [complete_clip]
+
+
+@pytest.mark.parametrize("payload", ["{", "not-json", '{"clips": [}'])
+def test_parse_clip_data_returns_empty_for_malformed_json(payload):
+    assert parse_clip_data(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("input_path", "expected_path"),
+    [
+        ("clip.mp4", "clip_shorts.mp4"),
+        ("/tmp/archive.name.mov", "/tmp/archive.name_shorts.mp4"),
+        ("extensionless", "extensionless_shorts.mp4"),
+    ],
+)
+def test_shorts_output_path(input_path, expected_path):
+    assert _shorts_output_path(input_path) == expected_path
+
+
+def test_convert_clip_to_shorts_builds_ffmpeg_command():
+    completed = subprocess.CompletedProcess(args=[], returncode=0)
+
+    with patch("gen_clip.run_command", return_value=completed) as run_command:
+        result, output_path = _convert_clip_to_shorts("clip.mp4")
+
+    assert result is completed
+    assert output_path == "clip_shorts.mp4"
+    assert run_command.call_args.args[0] == [
+        "ffmpeg",
+        "-y",
+        "-i",
+        "clip.mp4",
+        "-vf",
+        "scale=1080:1920:force_original_aspect_ratio=decrease,"
+        "pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        "clip_shorts.mp4",
+    ]
+
+
+def test_extract_clip_returns_failure_when_ffmpeg_fails(tmp_path):
+    completed = subprocess.CompletedProcess(args=[], returncode=1)
+
+    with patch("gen_clip.run_command", return_value=completed):
+        success, error = extract_clip("vod.mp4", tmp_path, valid_clip())
+
+    assert success is False
+    assert error == "FFmpeg failed with code 1"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_filename"),
+    [
+        ("folder/name", "foldername.mp4"),
+        ("🔥Highlight", "Highlight.mp4"),
+        ('"Quoted"', "Quoted.mp4"),
+    ],
+)
+def test_extract_clip_sanitizes_filename(tmp_path, name, expected_filename):
+    completed = subprocess.CompletedProcess(args=[], returncode=0)
+    clip_data = valid_clip()
+    clip_data["name"] = name
+
+    with (
+        patch("gen_clip.run_command", return_value=completed) as run_command,
+        patch("gen_clip.os.path.exists", return_value=True),
+    ):
+        success, output_file = extract_clip("vod.mp4", tmp_path, clip_data)
+
+    expected_output = str(Path(tmp_path) / expected_filename)
+    assert success is True
+    assert output_file == expected_output
+    assert run_command.call_args.args[0][-1] == expected_output

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -6,6 +6,8 @@ import types
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 # Add src to path to import processor
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -117,3 +119,77 @@ def test_process_single_file_passes_shorts_format_to_clips():
         min_score=0,
         shorts_format=True,
     )
+
+
+@pytest.mark.parametrize(
+    ("input_path", "expected_output"),
+    [
+        ("recording.ts", "recording.mp4"),
+        ("/tmp/archive.name.mkv", "/tmp/archive.name.mp4"),
+        ("/tmp/extensionless", "/tmp/extensionless.mp4"),
+    ],
+)
+def test_convert_builds_output_path_from_input_name(input_path, expected_output):
+    processor = object.__new__(Processor)
+
+    with patch("processor.run_command") as run_command:
+        output_path = processor._convert(input_path)
+
+    assert output_path == expected_output
+    assert run_command.call_args.args[0][-3:] == [expected_output, "-loglevel", "error"]
+
+
+def test_encode_uses_default_options():
+    streamer_config = configparser.ConfigParser()
+    streamer_config["encoding"] = {}
+    completed = subprocess.CompletedProcess(args=[], returncode=0)
+
+    with patch("processor.run_command", return_value=completed) as run_command:
+        output_path = Processor._encode(
+            object.__new__(Processor), "/tmp/input.mp4", streamer_config
+        )
+
+    assert output_path == "/tmp/input.reencoded.mp4"
+    assert run_command.call_args.args[0] == [
+        "ffmpeg",
+        "-i",
+        "/tmp/input.mp4",
+        "-c:v",
+        "libx265",
+        "-crf",
+        "25",
+        "-preset",
+        "medium",
+        "-c:a",
+        "copy",
+        "-loglevel",
+        "error",
+        "/tmp/input.reencoded.mp4",
+    ]
+
+
+def test_encode_returns_none_when_ffmpeg_fails():
+    streamer_config = configparser.ConfigParser()
+    streamer_config["encoding"] = {}
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stderr="encoding failed"
+    )
+
+    with patch("processor.run_command", return_value=completed):
+        output_path = Processor._encode(
+            object.__new__(Processor), "/tmp/input.mp4", streamer_config
+        )
+
+    assert output_path is None
+
+
+def test_encode_returns_none_when_command_raises():
+    streamer_config = configparser.ConfigParser()
+    streamer_config["encoding"] = {}
+
+    with patch("processor.run_command", side_effect=OSError("ffmpeg missing")):
+        output_path = Processor._encode(
+            object.__new__(Processor), "/tmp/input.mp4", streamer_config
+        )
+
+    assert output_path is None

--- a/tests/test_stream_manager.py
+++ b/tests/test_stream_manager.py
@@ -1,0 +1,114 @@
+import configparser
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from stream_manager import StreamManager
+
+
+def make_manager():
+    manager = object.__new__(StreamManager)
+    manager.monitors = {}
+    manager.running = False
+    manager.retry_delay = 120
+    return manager
+
+
+def test_get_streamers_list_returns_empty_without_config():
+    manager = make_manager()
+
+    with patch("stream_manager.config", None):
+        assert manager.get_streamers_list() == []
+
+
+def test_get_streamers_list_returns_empty_without_streamers_section():
+    manager = make_manager()
+
+    with patch("stream_manager.config", configparser.ConfigParser()):
+        assert manager.get_streamers_list() == []
+
+
+@pytest.mark.parametrize("configured_value", ["", "   ", ",,,"])
+def test_get_streamers_list_returns_empty_for_blank_values(configured_value):
+    manager = make_manager()
+    stream_config = configparser.ConfigParser()
+    stream_config["streamers"] = {"streamers": configured_value}
+
+    with patch("stream_manager.config", stream_config):
+        assert manager.get_streamers_list() == []
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected"),
+    [
+        ("alice", {"alice"}),
+        (" alice, bob ", {"alice", "bob"}),
+        (",alice,bob,", {"alice", "bob"}),
+        ("alice,,bob", {"alice", "bob"}),
+        ("alice,bob,alice", {"alice", "bob"}),
+    ],
+)
+def test_get_streamers_list_parses_configured_names(configured_value, expected):
+    manager = make_manager()
+    stream_config = configparser.ConfigParser()
+    stream_config["streamers"] = {"streamers": configured_value}
+
+    with patch("stream_manager.config", stream_config):
+        assert set(manager.get_streamers_list()) == expected
+
+
+def test_start_creates_and_starts_monitor_for_explicit_streamer():
+    manager = make_manager()
+    monitor = MagicMock()
+
+    with patch("stream_manager.StreamMonitor", return_value=monitor) as monitor_class:
+        manager.start("alice")
+
+    monitor_class.assert_called_once_with("alice", 120)
+    assert monitor.daemon is True
+    monitor.start.assert_called_once_with()
+    assert manager.monitors == {"alice": monitor}
+    assert manager.running is True
+
+
+def test_start_is_noop_when_manager_is_already_running():
+    manager = make_manager()
+    manager.running = True
+
+    with patch("stream_manager.StreamMonitor") as monitor_class:
+        manager.start("alice")
+
+    monitor_class.assert_not_called()
+
+
+def test_stop_stops_and_joins_each_monitor():
+    manager = make_manager()
+    first_monitor = MagicMock()
+    second_monitor = MagicMock()
+    manager.monitors = {"alice": first_monitor, "bob": second_monitor}
+    manager.running = True
+
+    manager.stop()
+
+    for monitor in (first_monitor, second_monitor):
+        monitor.stop.assert_called_once_with()
+        monitor.join.assert_called_once_with(timeout=0.02)
+    assert manager.monitors == {}
+    assert manager.running is False
+
+
+def test_list_monitored_streamers_returns_monitor_names():
+    manager = make_manager()
+    manager.monitors = {"alice": MagicMock(), "bob": MagicMock()}
+
+    assert manager.list_monitored_streamers() == ["alice", "bob"]
+
+
+def test_signal_handler_stops_manager_before_exiting():
+    manager = make_manager()
+
+    with patch.object(manager, "stop") as stop, pytest.raises(SystemExit) as raised:
+        manager._signal_handler(2, None)
+
+    stop.assert_called_once_with()
+    assert raised.value.code == 0


### PR DESCRIPTION
Closes #221.

## Summary

- cover Processor conversion and encoding command construction, defaults, and failures
- cover StreamManager parsing, duplicate/whitespace handling, lifecycle, and signal handling
- cover clip JSON loading/parsing, chunking, filename sanitization, and mocked FFmpeg command construction
- keep all subprocess and API boundaries mocked

## Results

- 83 tests passed (29 baseline, 54 added)
- `gen_clip.py`: 49% line coverage
- `processor.py`: 57% line coverage
- `stream_manager.py`: 62% line coverage

## Testing

- `uv run --with ".[test]" --with pytest-cov pytest --cov=processor --cov=stream_manager --cov=gen_clip --cov-report=term-missing`
- critical Flake8 checks: 0 errors
- Black check on all three changed test files
- `uv build`

## Existing lint state

The repository-wide Black check also reports pre-existing formatting in `src/transcription.py` and `tests/test_stream_monitor.py`. This test-only PR leaves those unrelated files unchanged.