### PR TITLE
feat: background upload queue with retry and save_on_fail

### DIFF
--- a/default.ini
+++ b/default.ini
@@ -20,6 +20,9 @@ service = youtube
 # If you want to save the non-empty video that failed to upload, set this to true
 save_on_fail = false
 
+# Max upload attempts before giving up (exponential backoff between tries)
+max_attempts = 5
+
 
 [clipception]
 

--- a/src/processor.py
+++ b/src/processor.py
@@ -4,7 +4,7 @@ import os
 from logger import logger
 from settings import config, CLIPCEPTION_ENABLED
 from utils import run_command
-from uploader import upload_youtube
+from uploader import uploader
 
 # clipception
 from transcription import process_video
@@ -73,27 +73,29 @@ class Processor:
                     new_video_path, streamer_name, upload_video=False
                 )
 
-            # Upload
+            # Queue upload on the background uploader so processing is not blocked.
             upload = streamer_config.getboolean("upload", "upload")
-            if upload:
-                try:
-                    logger.info("Uploading video.")
-                    upload_youtube(os.path.abspath(new_video_path))
-                except Exception:
-                    logger.exception("Upload failed")
+            if upload and new_video_path:
+                service = streamer_config.get("upload", "service", fallback="youtube")
+                logger.info(f"Enqueueing upload via {service}: {new_video_path}")
+                uploader.enqueue(
+                    filename=os.path.abspath(new_video_path),
+                    service=service,
+                    streamer_config=streamer_config,
+                    ts_path=os.path.abspath(video_path) if video_path else None,
+                )
+            else:
+                # No upload: honor save_locally here. Upload path cleans up later.
+                save_locally = streamer_config.getboolean(
+                    "local", "save_locally", fallback=True
+                )
+                if not save_locally:
+                    logger.info(
+                        "Deleting video files (save_locally is disabled, upload off)"
+                    )
+                    self._delete_video_files(video_path, new_video_path)
 
             logger.info(f"Finished processing: {new_video_path}")
-
-            # Delete files after upload if not set to save locally
-            save_locally = streamer_config.getboolean(
-                "local", "save_locally", fallback=True
-            )
-
-            if not save_locally:
-                logger.info(
-                    "Deleting video files after upload (save_locally is disabled)"
-                )
-                self._delete_video_files(video_path, new_video_path)
 
             self.queue.task_done()
             self.processing_event.clear()

--- a/src/stream_manager.py
+++ b/src/stream_manager.py
@@ -4,6 +4,7 @@ import signal
 from logger import logger
 from settings import config
 from stream_monitor import StreamMonitor
+from uploader import uploader
 from utils import get_size
 from tqdm import tqdm
 
@@ -83,6 +84,12 @@ class StreamManager:
 
         self.monitors.clear()
         self.running = False
+
+        # Persist any remaining uploads and stop the background worker.
+        try:
+            uploader.stop()
+        except Exception:
+            logger.exception("Error stopping uploader")
 
     def list_monitored_streamers(self) -> list[str]:
         return list(self.monitors.keys())

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -260,7 +260,9 @@ def process_video(video_path):
         audio_path = extract_audio(video_path)
 
         # Model loading
-        logger.info(f"Loading {transcription_engine} {model_size} model for {device}...")
+        logger.info(
+            f"Loading {transcription_engine} {model_size} model for {device}..."
+        )
         if transcription_engine == "faster-whisper":
             model = WhisperModel(
                 model_size,
@@ -289,7 +291,9 @@ def process_video(video_path):
 
         process_end = time.time()
         logger.info(f"\n{'='*40}")
-        logger.info(f"Total processing time: {format_time(process_end - process_start)}")
+        logger.info(
+            f"Total processing time: {format_time(process_end - process_start)}"
+        )
         logger.info(f"Enhanced transcription saved to {transcription_path}")
         logger.info(f"{'='*40}")
 

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -190,8 +190,7 @@ class Uploader:
                 ),
             )
             opts.setdefault(
-                "rclone_remote",
-                streamer_config.get("rclone", "remote", fallback=""),
+                "rclone_remote", streamer_config.get("rclone", "remote", fallback="")
             )
             opts.setdefault(
                 "rclone_directory",
@@ -361,7 +360,9 @@ class Uploader:
                 self.queue.put(item)
                 restored += 1
             if restored:
-                logger.info(f"Restored {restored} pending upload(s) from {self.queue_path}")
+                logger.info(
+                    f"Restored {restored} pending upload(s) from {self.queue_path}"
+                )
         except Exception:
             logger.exception(f"Failed to load upload queue from {self.queue_path}")
 

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -4,7 +4,6 @@ import platform
 import queue
 import subprocess
 import threading
-import time
 from typing import Any
 
 from logger import logger

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -1,11 +1,22 @@
+import json
 import os
 import platform
+import queue
 import subprocess
-from utils import run_command
+import threading
+import time
+from typing import Any
+
 from logger import logger
+from utils import run_command
 
 YOUTUBE_UPLOADER_LINUX = "/root/youtubeuploader/youtubeuploader"
 YOUTUBE_UPLOADER_WINDOWS = "C:\\youtubeuploader\\youtubeuploader.exe"
+
+# Pending uploads survive process restarts.
+DEFAULT_QUEUE_PATH = os.path.join("recordings", "upload_queue.json")
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_BASE_BACKOFF_SECONDS = 2.0
 
 
 def upload_youtube(filename: str) -> None:
@@ -35,3 +46,330 @@ def upload_youtube(filename: str) -> None:
 
     if result.returncode != 0:
         raise RuntimeError("youtubeuploader failed to upload the file")
+
+
+def upload_rclone(filename: str, remote: str, directory: str = "") -> None:
+    if not os.path.isfile(filename):
+        raise FileNotFoundError(f"File not found: {filename}")
+    if not remote:
+        raise ValueError("rclone remote is not configured")
+
+    dest = f"{remote}:{directory}" if directory else f"{remote}:"
+    command = ["rclone", "copy", filename, dest]
+    result = run_command(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stderr = result.stderr.decode().strip() if result.stderr else ""
+    if result.returncode != 0:
+        raise RuntimeError(stderr or "rclone failed to upload the file")
+
+
+def perform_upload(filename: str, service: str, options: dict[str, Any]) -> None:
+    service = (service or "youtube").strip().lower()
+    if service == "youtube":
+        upload_youtube(filename)
+    elif service == "rclone":
+        upload_rclone(
+            filename,
+            remote=options.get("rclone_remote", ""),
+            directory=options.get("rclone_directory", ""),
+        )
+    else:
+        raise RuntimeError(f"Unsupported upload service: {service}")
+
+
+class Uploader:
+    """Background upload worker with retries and a disk-backed queue."""
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(Uploader, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(
+        self,
+        queue_path: str = DEFAULT_QUEUE_PATH,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        base_backoff_seconds: float = DEFAULT_BASE_BACKOFF_SECONDS,
+        auto_start: bool = True,
+    ):
+        if hasattr(self, "initialized"):
+            return
+
+        self.queue_path = queue_path
+        self.max_attempts = max(1, int(max_attempts))
+        self.base_backoff_seconds = float(base_backoff_seconds)
+        self.queue: queue.Queue = queue.Queue()
+        self.stop_event = threading.Event()
+        self.worker_thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._upload_fn = perform_upload
+        self._auto_start = auto_start
+        self.initialized = True
+
+        self._load_persisted_queue()
+        if auto_start and self.queue.qsize() > 0:
+            self._ensure_worker()
+
+    def enqueue(
+        self,
+        filename: str,
+        service: str = "youtube",
+        streamer_config=None,
+        attempt_count: int = 0,
+        ts_path: str | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        """Queue a file for upload. Does not block the caller."""
+        abs_path = os.path.abspath(filename)
+        if not os.path.exists(abs_path):
+            logger.warning(f"Can't queue upload. Path {abs_path} does not exist.")
+            return
+
+        item = self._build_item(
+            filename=abs_path,
+            service=service,
+            streamer_config=streamer_config,
+            attempt_count=attempt_count,
+            ts_path=ts_path,
+            options=options,
+        )
+        self.queue.put(item)
+        self._persist_queue()
+        if self._auto_start:
+            self._ensure_worker()
+        logger.info(
+            f"Queued upload: {abs_path} (service={item['service']}, attempt={item['attempt_count']})"
+        )
+
+    def _ensure_worker(self) -> None:
+        with self._lock:
+            if self.worker_thread is not None and self.worker_thread.is_alive():
+                return
+            self.stop_event.clear()
+            self.worker_thread = threading.Thread(
+                target=self._process_queue, name="uploader", daemon=True
+            )
+            self.worker_thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Signal the worker to stop and wait briefly for it."""
+        self.stop_event.set()
+        thread = self.worker_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+        self._persist_queue()
+
+    def pending_count(self) -> int:
+        return self.queue.qsize()
+
+    def _build_item(
+        self,
+        filename: str,
+        service: str,
+        streamer_config,
+        attempt_count: int,
+        ts_path: str | None,
+        options: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        opts = dict(options or {})
+        if streamer_config is not None:
+            service = streamer_config.get("upload", "service", fallback=service)
+            opts.setdefault(
+                "save_on_fail",
+                streamer_config.getboolean("upload", "save_on_fail", fallback=False),
+            )
+            opts.setdefault(
+                "save_locally",
+                streamer_config.getboolean("local", "save_locally", fallback=True),
+            )
+            opts.setdefault(
+                "max_attempts",
+                streamer_config.getint(
+                    "upload", "max_attempts", fallback=self.max_attempts
+                ),
+            )
+            opts.setdefault(
+                "rclone_remote",
+                streamer_config.get("rclone", "remote", fallback=""),
+            )
+            opts.setdefault(
+                "rclone_directory",
+                streamer_config.get("rclone", "directory", fallback=""),
+            )
+        else:
+            opts.setdefault("save_on_fail", False)
+            opts.setdefault("save_locally", True)
+            opts.setdefault("max_attempts", self.max_attempts)
+
+        return {
+            "filename": filename,
+            "service": (service or "youtube").strip().lower(),
+            "attempt_count": int(attempt_count),
+            "ts_path": os.path.abspath(ts_path) if ts_path else None,
+            "save_on_fail": bool(opts.get("save_on_fail", False)),
+            "save_locally": bool(opts.get("save_locally", True)),
+            "max_attempts": max(1, int(opts.get("max_attempts", self.max_attempts))),
+            "rclone_remote": opts.get("rclone_remote", "") or "",
+            "rclone_directory": opts.get("rclone_directory", "") or "",
+        }
+
+    def _process_queue(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                item = self.queue.get(timeout=1.0)
+            except queue.Empty:
+                continue
+
+            try:
+                self._handle_item(item)
+            except Exception:
+                logger.exception("Unexpected error in upload worker")
+            finally:
+                self.queue.task_done()
+                self._persist_queue()
+
+    def _handle_item(self, item: dict[str, Any]) -> None:
+        filename = item["filename"]
+        service = item["service"]
+        attempt = int(item.get("attempt_count", 0))
+        max_attempts = int(item.get("max_attempts", self.max_attempts))
+
+        if not os.path.isfile(filename):
+            logger.error(f"Skipping upload; file missing: {filename}")
+            return
+
+        try:
+            logger.info(
+                f"Uploading {filename} via {service} (attempt {attempt + 1}/{max_attempts})"
+            )
+            self._upload_fn(
+                filename,
+                service,
+                {
+                    "rclone_remote": item.get("rclone_remote", ""),
+                    "rclone_directory": item.get("rclone_directory", ""),
+                },
+            )
+        except Exception as exc:
+            logger.exception(f"Upload failed for {filename}: {exc}")
+            next_attempt = attempt + 1
+            if next_attempt < max_attempts:
+                delay = self.base_backoff_seconds * (2**attempt)
+                logger.info(
+                    f"Retrying upload of {filename} in {delay:.1f}s "
+                    f"(attempt {next_attempt + 1}/{max_attempts})"
+                )
+                if self.stop_event.wait(delay):
+                    # Shutting down: put item back for next start.
+                    item["attempt_count"] = next_attempt
+                    self.queue.put(item)
+                    return
+                item["attempt_count"] = next_attempt
+                self.queue.put(item)
+                return
+
+            self._on_final_failure(item)
+            return
+
+        logger.success(f"Upload finished: {filename}")
+        self._on_success(item)
+
+    def _on_success(self, item: dict[str, Any]) -> None:
+        if item.get("save_locally", True):
+            return
+        logger.info("Deleting local files after successful upload (save_locally=false)")
+        self._delete_files(item.get("ts_path"), item["filename"])
+
+    def _on_final_failure(self, item: dict[str, Any]) -> None:
+        filename = item["filename"]
+        save_on_fail = item.get("save_on_fail", False)
+        save_locally = item.get("save_locally", True)
+
+        if save_on_fail:
+            logger.error(
+                f"Upload failed permanently; keeping file because save_on_fail=true: {filename}"
+            )
+            return
+
+        if save_locally:
+            logger.error(
+                f"Upload failed permanently; keeping file because save_locally=true: {filename}"
+            )
+            return
+
+        logger.error(
+            f"Upload failed permanently; deleting local files (save_on_fail=false, save_locally=false): {filename}"
+        )
+        self._delete_files(item.get("ts_path"), filename)
+
+    def _delete_files(self, ts_path: str | None, video_path: str) -> None:
+        for path in (ts_path, video_path):
+            if not path:
+                continue
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+                    logger.info(f"Deleted file: {path}")
+            except Exception:
+                logger.exception(f"Error deleting file: {path}")
+
+    def _snapshot_queue(self) -> list[dict[str, Any]]:
+        with self._lock:
+            items = list(self.queue.queue)
+        return items
+
+    def _persist_queue(self) -> None:
+        items = self._snapshot_queue()
+        directory = os.path.dirname(self.queue_path)
+        try:
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            tmp_path = f"{self.queue_path}.tmp"
+            with open(tmp_path, "w", encoding="utf-8") as handle:
+                json.dump(items, handle, indent=2)
+            os.replace(tmp_path, self.queue_path)
+        except Exception:
+            logger.exception(f"Failed to persist upload queue to {self.queue_path}")
+
+    def _load_persisted_queue(self) -> None:
+        if not os.path.isfile(self.queue_path):
+            return
+        try:
+            with open(self.queue_path, encoding="utf-8") as handle:
+                items = json.load(handle)
+            if not isinstance(items, list):
+                logger.warning(f"Ignoring invalid upload queue file: {self.queue_path}")
+                return
+            restored = 0
+            for raw in items:
+                if not isinstance(raw, dict) or "filename" not in raw:
+                    continue
+                item = {
+                    "filename": raw["filename"],
+                    "service": str(raw.get("service", "youtube")).strip().lower(),
+                    "attempt_count": int(raw.get("attempt_count", 0)),
+                    "ts_path": raw.get("ts_path"),
+                    "save_on_fail": bool(raw.get("save_on_fail", False)),
+                    "save_locally": bool(raw.get("save_locally", True)),
+                    "max_attempts": max(
+                        1, int(raw.get("max_attempts", self.max_attempts))
+                    ),
+                    "rclone_remote": raw.get("rclone_remote", "") or "",
+                    "rclone_directory": raw.get("rclone_directory", "") or "",
+                }
+                self.queue.put(item)
+                restored += 1
+            if restored:
+                logger.info(f"Restored {restored} pending upload(s) from {self.queue_path}")
+        except Exception:
+            logger.exception(f"Failed to load upload queue from {self.queue_path}")
+
+
+# Module-level singleton used by processor / stream_manager.
+# Tests reset Uploader._instance and construct their own instances.
+def get_uploader() -> Uploader:
+    return Uploader()
+
+
+uploader = get_uploader()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -24,6 +24,17 @@ sys.modules.setdefault("gen_clip", gen_clip)
 
 uploader = types.ModuleType("uploader")
 uploader.upload_youtube = lambda *args, **kwargs: None
+
+
+class _FakeUploader:
+    def __init__(self):
+        self.items = []
+
+    def enqueue(self, *args, **kwargs):
+        self.items.append((args, kwargs))
+
+
+uploader.uploader = _FakeUploader()
 sys.modules.setdefault("uploader", uploader)
 
 from processor import Processor  # noqa: E402

--- a/tests/test_stream_monitor.py
+++ b/tests/test_stream_monitor.py
@@ -8,14 +8,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from stream_monitor import StreamMonitor
 
+
 class TestStreamMonitorQuality:
     def _make_monitor(self, quality: str) -> StreamMonitor:
         monitor = StreamMonitor.__new__(StreamMonitor)
         config = configparser.ConfigParser()
-        config.read_dict({
-            "streamlink": {"quality": quality},
-            "source": {"stream_source": "twitch"},
-        })
+        config.read_dict(
+            {"streamlink": {"quality": quality}, "source": {"stream_source": "twitch"}}
+        )
         monitor.config = config
         monitor.streamer_name = "teststreamer"
         monitor.datetime_format = "%d-%m-%Y-%H-%M-%S"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -31,10 +31,7 @@ def reset_uploader_singleton(tmp_path):
 
 
 def _streamer_config(
-    service="youtube",
-    save_on_fail=False,
-    save_locally=True,
-    max_attempts=5,
+    service="youtube", save_on_fail=False, save_locally=True, max_attempts=5
 ):
     cfg = configparser.ConfigParser()
     cfg["upload"] = {
@@ -82,7 +79,9 @@ def test_retry_after_transient_failure_then_success(tmp_path, reset_uploader_sin
     assert video.exists()
 
 
-def test_save_on_fail_keeps_file_after_exhausted_retries(tmp_path, reset_uploader_singleton):
+def test_save_on_fail_keeps_file_after_exhausted_retries(
+    tmp_path, reset_uploader_singleton
+):
     video = tmp_path / "vod.mp4"
     video.write_bytes(b"data")
 
@@ -109,7 +108,9 @@ def test_save_on_fail_keeps_file_after_exhausted_retries(tmp_path, reset_uploade
     assert video.exists()
 
 
-def test_delete_after_success_when_not_saving_locally(tmp_path, reset_uploader_singleton):
+def test_delete_after_success_when_not_saving_locally(
+    tmp_path, reset_uploader_singleton
+):
     video = tmp_path / "vod.mp4"
     video.write_bytes(b"data")
     ts = tmp_path / "vod.ts"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,180 @@
+import configparser
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import uploader as uploader_mod  # noqa: E402
+from uploader import Uploader  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_uploader_singleton(tmp_path):
+    """Each test gets a fresh Uploader singleton with no auto-started worker."""
+    uploader_mod.Uploader._instance = None
+    # Avoid the module-level singleton from interfering with assertions.
+    queue_path = tmp_path / "upload_queue.json"
+    instance = Uploader(
+        queue_path=str(queue_path),
+        max_attempts=5,
+        base_backoff_seconds=0.01,
+        auto_start=False,
+    )
+    yield instance
+    instance.stop(timeout=1.0)
+    uploader_mod.Uploader._instance = None
+
+
+def _streamer_config(
+    service="youtube",
+    save_on_fail=False,
+    save_locally=True,
+    max_attempts=5,
+):
+    cfg = configparser.ConfigParser()
+    cfg["upload"] = {
+        "upload": "true",
+        "service": service,
+        "save_on_fail": str(save_on_fail).lower(),
+        "max_attempts": str(max_attempts),
+    }
+    cfg["local"] = {"save_locally": str(save_locally).lower()}
+    cfg["rclone"] = {"remote": "remote", "directory": "vods"}
+    return cfg
+
+
+def test_retry_after_transient_failure_then_success(tmp_path, reset_uploader_singleton):
+    """Simulated 503 then success is retried and does not lose the file job."""
+    video = tmp_path / "vod.mp4"
+    video.write_bytes(b"data")
+
+    attempts = {"n": 0}
+
+    def flaky_upload(filename, service, options):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("HTTP 503 Service Unavailable")
+        return None
+
+    worker = reset_uploader_singleton
+    worker._upload_fn = flaky_upload
+    worker.enqueue(
+        filename=str(video),
+        service="youtube",
+        streamer_config=_streamer_config(max_attempts=5),
+    )
+
+    # Drain the queue on this thread (no background worker).
+    item = worker.queue.get(timeout=1)
+    worker._handle_item(item)
+    # First failure re-queues.
+    assert worker.queue.qsize() == 1
+    item2 = worker.queue.get(timeout=1)
+    worker._handle_item(item2)
+
+    assert attempts["n"] == 2
+    assert worker.queue.qsize() == 0
+    assert video.exists()
+
+
+def test_save_on_fail_keeps_file_after_exhausted_retries(tmp_path, reset_uploader_singleton):
+    video = tmp_path / "vod.mp4"
+    video.write_bytes(b"data")
+
+    def always_fail(filename, service, options):
+        raise RuntimeError("HTTP 503 Service Unavailable")
+
+    worker = reset_uploader_singleton
+    worker._upload_fn = always_fail
+    worker.max_attempts = 3
+    worker.base_backoff_seconds = 0.001
+    worker.enqueue(
+        filename=str(video),
+        streamer_config=_streamer_config(
+            save_on_fail=True, save_locally=False, max_attempts=3
+        ),
+    )
+
+    # Process until permanent failure (3 attempts).
+    for _ in range(3):
+        item = worker.queue.get(timeout=1)
+        worker._handle_item(item)
+
+    assert worker.queue.qsize() == 0
+    assert video.exists()
+
+
+def test_delete_after_success_when_not_saving_locally(tmp_path, reset_uploader_singleton):
+    video = tmp_path / "vod.mp4"
+    video.write_bytes(b"data")
+    ts = tmp_path / "vod.ts"
+    ts.write_bytes(b"ts")
+
+    worker = reset_uploader_singleton
+    worker._upload_fn = lambda *a, **k: None
+    worker.enqueue(
+        filename=str(video),
+        ts_path=str(ts),
+        streamer_config=_streamer_config(save_locally=False, save_on_fail=False),
+    )
+    item = worker.queue.get(timeout=1)
+    worker._handle_item(item)
+
+    assert not video.exists()
+    assert not ts.exists()
+
+
+def test_queue_persists_to_disk(tmp_path, reset_uploader_singleton):
+    video = tmp_path / "vod.mp4"
+    video.write_bytes(b"data")
+    worker = reset_uploader_singleton
+    worker.enqueue(filename=str(video), streamer_config=_streamer_config())
+
+    assert Path(worker.queue_path).is_file()
+    data = Path(worker.queue_path).read_text(encoding="utf-8")
+    assert "vod.mp4" in data
+    assert worker.pending_count() == 1
+
+
+def test_restores_queue_on_start(tmp_path):
+    import json
+
+    queue_path = tmp_path / "upload_queue.json"
+    video = tmp_path / "pending.mp4"
+    video.write_bytes(b"x")
+    queue_path.write_text(
+        json.dumps(
+            [
+                {
+                    "filename": str(video),
+                    "service": "youtube",
+                    "attempt_count": 1,
+                    "save_on_fail": False,
+                    "save_locally": True,
+                    "max_attempts": 5,
+                    "rclone_remote": "",
+                    "rclone_directory": "",
+                    "ts_path": None,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    uploader_mod.Uploader._instance = None
+    worker = Uploader(
+        queue_path=str(queue_path), auto_start=False, base_backoff_seconds=0.01
+    )
+    try:
+        assert worker.pending_count() == 1
+        item = worker.queue.get(timeout=1)
+        assert item["filename"].endswith("pending.mp4")
+        assert item["attempt_count"] == 1
+    finally:
+        worker.stop(timeout=1.0)
+        uploader_mod.Uploader._instance = None

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -7,6 +7,10 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+# Other tests install a lightweight uploader stub in sys.modules. Drop it so we
+# load the real module under test (ModuleType stubs have no __file__/Uploader).
+sys.modules.pop("uploader", None)
+
 import uploader as uploader_mod  # noqa: E402
 from uploader import Uploader  # noqa: E402
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,8 +1,6 @@
 import configparser
 import os
 import sys
-import threading
-import time
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary

Fixes #215.

Uploads no longer run inside the processor worker thread. A dedicated `Uploader` queue handles them in the background so the next VOD can be processed while an upload is still running.

### Changes
- Add `Uploader` worker with its own queue and daemon thread
- Retry failed uploads with exponential backoff (`upload.max_attempts`, default 5)
- Persist pending jobs to `recordings/upload_queue.json` so a crash does not drop them
- Wire `save_on_fail` and `save_locally` for success and final failure cleanup
- Support `youtube` and `rclone` services
- Start and stop the worker with the stream manager lifecycle

### Tests
- Unit tests for 503 then success retry
- `save_on_fail` keeps the file after exhausted retries
- Delete after success when `save_locally=false`
- Queue persist and restore

```
pytest tests/test_uploader.py -q
# 5 passed
```