### PR TITLE
chore: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "py-autovod",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent setup for py-autovod.
+# Installs system media tooling, the uv package manager, and the project
+# (with dev + lint dependencies) into a project-local virtual environment.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "[install] Installing system dependencies (ffmpeg, streamlink)..."
+sudo apt-get update -qq
+sudo apt-get install -y -qq --no-install-recommends ffmpeg streamlink
+
+echo "[install] Ensuring uv is available..."
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+uv --version
+
+echo "[install] Creating virtual environment (.venv)..."
+if [ ! -x .venv/bin/python ]; then
+  uv venv --python 3.12 .venv
+else
+  echo "[install] .venv already exists, reusing it."
+fi
+
+echo "[install] Installing project with dev and lint dependencies..."
+# flake8 is used by the lint CI workflow but is not declared in pyproject extras.
+uv pip install --python .venv/bin/python -e ".[dev]" flake8
+
+echo "[install] Done. Activate with: source .venv/bin/activate"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent development environment for `py-autovod` so future agents boot into a ready-to-use setup. Because a committed `.cursor/environment.json` is the highest-precedence environment source, this takes effect once merged — no dashboard configuration is required.

- `.cursor/environment.json` — runs the install script during environment setup.
- `.cursor/install.sh` — idempotent bootstrap that installs system media tooling (`ffmpeg`, `streamlink`), the `uv` package manager, and the project with dev + lint dependencies into a project-local `.venv`.

## Design notes

- Uses Cursor's default base image and installs the two missing system dependencies (`ffmpeg`, `streamlink`) via `apt` in the install phase, mirroring the project's own `install.sh`.
- Installs the package with `uv pip install -e ".[dev]" flake8`, matching the CI stack (`.[dev]`/`.[test]` pull the full runtime deps including `torch`/Whisper; `flake8` is used by the lint workflow but isn't declared in the extras).
- Idempotent: it reuses an existing `.venv` and re-runs converge without error.
- Activate with `source .venv/bin/activate`.

## Validation

Local VM:

| Check | Result |
| --- | --- |
| `autovod --version` | `1.2.1` |
| `pytest` | 88 passed |
| `flake8` (E9,F63,F7,F82) | 0 errors |
| `black --check` | 22 files unchanged |
| Clip extraction + shorts (1080x1920) | 2 clips + 2 shorts generated |
| Transcription pipeline (torch + faster-whisper) | model loaded, audio transcribed, JSON saved |
| Install idempotence | Passed across clean + repeat runs |

Environment builds (draft, off this branch):

| Build | Base | Result |
| --- | --- | --- |
| `bld-20260910-40becf9f...` | Working-VM snapshot | SUCCEEDED — install re-ran clean |
| `bld-20260910-ca346d5a...` | Default image (from scratch) | SUCCEEDED — fresh `apt` streamlink, `uv` via curl, full `torch` download |

Fresh Cloud Agent booted from `bld-20260910-40becf9f...`: ffmpeg 6.1.1 / streamlink 6.6.2, torch 2.14.0, `autovod` 1.2.1, 88 tests passed, flake8 0 errors, black clean, and offline clip extraction produced 2 clips — all passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abc81fe2-f3e9-47b7-886d-514f92c9808b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abc81fe2-f3e9-47b7-886d-514f92c9808b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

