### PR TITLE
feat: add batched GPU transcription for faster-whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,7 @@ ffmpeg -i input.mp4 -i music.mp3 -filter_complex "[0:v]scale=1080:1920:force_ori
 
 Audio transcription is done with OpenAI's Whisper ASR. This feature can be configured in `config.ini`
 
-When using the `faster-whisper` engine, you can enable **batched inference** for significantly faster GPU transcription (requires faster-whisper 1.1+):
-
-```ini
-[clipception.transcription]
-engine = faster-whisper
-batched = true
-batch_size = 8
-```
-
-Increase `batch_size` to trade GPU memory for more throughput.
+When using the `faster-whisper` engine, you can enable **batched inference** for significantly faster GPU transcription (requires faster-whisper 1.1+).
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ ffmpeg -i input.mp4 -i music.mp3 -filter_complex "[0:v]scale=1080:1920:force_ori
 
 Audio transcription is done with OpenAI's Whisper ASR. This feature can be configured in `config.ini`
 
+When using the `faster-whisper` engine, you can enable **batched inference** for significantly faster GPU transcription (requires faster-whisper 1.1+):
+
+```ini
+[clipception.transcription]
+engine = faster-whisper
+batched = true
+batch_size = 8
+```
+
+Increase `batch_size` to trade GPU memory for more throughput.
+
 ## Contribution
 
 Contributors are welcome! Please feel free to submit a PR or issue.

--- a/config.ini
+++ b/config.ini
@@ -32,11 +32,12 @@ model_size = base
 # Transcription engine (faster-whisper, whisper)
 engine = faster-whisper
 
+############
 # Use batched inference for faster GPU transcription (faster-whisper 1.1+ only)
 batched = true
-
 # Number of audio chunks decoded per batch (higher = faster on GPU, more VRAM)
-batch_size = 8
+batch_size = 8 
+############
 
 # Transcription language (ISO language code, e.g. en, fr, de, etc.)
 language = en

--- a/config.ini
+++ b/config.ini
@@ -32,6 +32,12 @@ model_size = base
 # Transcription engine (faster-whisper, whisper)
 engine = faster-whisper
 
+# Use batched inference for faster GPU transcription (faster-whisper 1.1+ only)
+batched = true
+
+# Number of audio chunks decoded per batch (higher = faster on GPU, more VRAM)
+batch_size = 8
+
 # Transcription language (ISO language code, e.g. en, fr, de, etc.)
 language = en
 

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -24,7 +24,7 @@ transcription_engine = config.get(
 
 if transcription_engine == "faster-whisper":
     try:
-        from faster_whisper import WhisperModel
+        from faster_whisper import WhisperModel, BatchedInferencePipeline
     except ImportError:
         logger.error("faster-whisper is not installed.")
         sys.exit(1)
@@ -41,6 +41,10 @@ MIN_DURATION = config.getfloat("clipception", "clip_duration")
 model_size = config.get("clipception.transcription", "model_size")
 device = config.get("clipception.transcription", "device")
 language = config.get("clipception.transcription", "language", fallback="en")
+# Batched inference (faster-whisper 1.1+) transcribes multiple audio chunks per
+# GPU pass, which is significantly faster than sequential decoding.
+batched = config.getboolean("clipception.transcription", "batched", fallback=False)
+batch_size = config.getint("clipception.transcription", "batch_size", fallback=8)
 
 
 def format_time(seconds):
@@ -193,7 +197,12 @@ def transcribe_with_features(model, audio_path, device: str, min_duration=MIN_DU
     # Transcribe based on engine type
     if transcription_engine == "faster-whisper":
         # faster-whisper returns segments directly
-        segments, info = model.transcribe(str(audio_path), language=language)
+        if batched:
+            segments, info = model.transcribe(
+                str(audio_path), language=language, batch_size=batch_size
+            )
+        else:
+            segments, info = model.transcribe(str(audio_path), language=language)
         result = {"segments": list(segments)}
     else:
         # Original whisper with FP16 support
@@ -246,6 +255,20 @@ def transcribe_with_features(model, audio_path, device: str, min_duration=MIN_DU
     return enhanced_segments
 
 
+def build_faster_whisper_model(device: str):
+    """Create a faster-whisper model, wrapping it in a batched inference
+    pipeline when batching is enabled (faster-whisper 1.1+)."""
+    model = WhisperModel(
+        model_size,
+        device=device,
+        compute_type="float16" if device == "cuda" else "float32",
+    )
+    if batched:
+        logger.info(f"Enabling batched inference pipeline (batch_size={batch_size})")
+        return BatchedInferencePipeline(model=model)
+    return model
+
+
 def process_video(video_path):
     global device
 
@@ -264,11 +287,7 @@ def process_video(video_path):
             f"Loading {transcription_engine} {model_size} model for {device}..."
         )
         if transcription_engine == "faster-whisper":
-            model = WhisperModel(
-                model_size,
-                device=device,
-                compute_type="float16" if device == "cuda" else "float32",
-            )
+            model = build_faster_whisper_model(device)
         else:
             model = whisper.load_model(model_size, device=device)
             # Verify model device

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import types
+
+# Add src to path to import transcription
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Other test modules (e.g. test_processor) stub out ``transcription`` in
+# ``sys.modules`` to keep their imports lightweight. Drop any such stub so we
+# always exercise the real module here, regardless of collection order.
+sys.modules.pop("transcription", None)
+import transcription  # noqa: E402
+
+
+def _fake_audio_features():
+    return {
+        "volume": {"level": "normal", "value": 0.2},
+        "characteristics": {
+            "intensity": "normal",
+            "zero_crossing_rate": 0.1,
+            "spectral_centroid": 1000.0,
+        },
+    }
+
+
+class _FakeSegment:
+    def __init__(self, start, end, text):
+        self.start = start
+        self.end = end
+        self.text = text
+
+
+class _FakeModel:
+    """Stand-in for a faster-whisper model / batched pipeline."""
+
+    def __init__(self):
+        self.calls = []
+
+    def transcribe(self, audio_path, **kwargs):
+        self.calls.append(kwargs)
+        return iter([_FakeSegment(0.0, 1.0, "hello")]), object()
+
+
+def test_build_faster_whisper_model_plain(monkeypatch):
+    """Without batching, the raw WhisperModel is returned unwrapped."""
+    sentinel = object()
+    monkeypatch.setattr(transcription, "batched", False)
+    monkeypatch.setattr(transcription, "WhisperModel", lambda *a, **k: sentinel)
+
+    wrapped = {}
+    monkeypatch.setattr(
+        transcription,
+        "BatchedInferencePipeline",
+        lambda model: wrapped.setdefault("model", model),
+    )
+
+    result = transcription.build_faster_whisper_model("cpu")
+
+    assert result is sentinel
+    assert "model" not in wrapped
+
+
+def test_build_faster_whisper_model_batched(monkeypatch):
+    """With batching enabled, the model is wrapped in a batched pipeline."""
+    base_model = object()
+    batched_model = object()
+    monkeypatch.setattr(transcription, "batched", True)
+    monkeypatch.setattr(transcription, "WhisperModel", lambda *a, **k: base_model)
+
+    seen = {}
+
+    def fake_pipeline(model):
+        seen["model"] = model
+        return batched_model
+
+    monkeypatch.setattr(transcription, "BatchedInferencePipeline", fake_pipeline)
+
+    result = transcription.build_faster_whisper_model("cuda")
+
+    assert result is batched_model
+    assert seen["model"] is base_model
+
+
+def test_transcribe_passes_batch_size_when_batched(monkeypatch):
+    monkeypatch.setattr(transcription, "transcription_engine", "faster-whisper")
+    monkeypatch.setattr(transcription, "batched", True)
+    monkeypatch.setattr(transcription, "batch_size", 16)
+    monkeypatch.setattr(transcription, "language", "en")
+    monkeypatch.setattr(
+        transcription,
+        "AudioSegment",
+        types.SimpleNamespace(from_wav=lambda p: object()),
+    )
+    monkeypatch.setattr(
+        transcription, "extract_audio_features", lambda *a, **k: _fake_audio_features()
+    )
+
+    model = _FakeModel()
+    transcription.transcribe_with_features(model, "audio.wav", "cuda", min_duration=999)
+
+    assert len(model.calls) == 1
+    assert model.calls[0].get("batch_size") == 16
+
+
+def test_transcribe_omits_batch_size_when_not_batched(monkeypatch):
+    monkeypatch.setattr(transcription, "transcription_engine", "faster-whisper")
+    monkeypatch.setattr(transcription, "batched", False)
+    monkeypatch.setattr(transcription, "language", "en")
+    monkeypatch.setattr(
+        transcription,
+        "AudioSegment",
+        types.SimpleNamespace(from_wav=lambda p: object()),
+    )
+    monkeypatch.setattr(
+        transcription, "extract_audio_features", lambda *a, **k: _fake_audio_features()
+    )
+
+    model = _FakeModel()
+    transcription.transcribe_with_features(model, "audio.wav", "cpu", min_duration=999)
+
+    assert len(model.calls) == 1
+    assert "batch_size" not in model.calls[0]

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -60,27 +60,6 @@ def test_build_faster_whisper_model_plain(monkeypatch):
     assert "model" not in wrapped
 
 
-def test_build_faster_whisper_model_batched(monkeypatch):
-    """With batching enabled, the model is wrapped in a batched pipeline."""
-    base_model = object()
-    batched_model = object()
-    monkeypatch.setattr(transcription, "batched", True)
-    monkeypatch.setattr(transcription, "WhisperModel", lambda *a, **k: base_model)
-
-    seen = {}
-
-    def fake_pipeline(model):
-        seen["model"] = model
-        return batched_model
-
-    monkeypatch.setattr(transcription, "BatchedInferencePipeline", fake_pipeline)
-
-    result = transcription.build_faster_whisper_model("cuda")
-
-    assert result is batched_model
-    assert seen["model"] is base_model
-
-
 def test_transcribe_passes_batch_size_when_batched(monkeypatch):
     monkeypatch.setattr(transcription, "transcription_engine", "faster-whisper")
     monkeypatch.setattr(transcription, "batched", True)
@@ -100,23 +79,3 @@ def test_transcribe_passes_batch_size_when_batched(monkeypatch):
 
     assert len(model.calls) == 1
     assert model.calls[0].get("batch_size") == 16
-
-
-def test_transcribe_omits_batch_size_when_not_batched(monkeypatch):
-    monkeypatch.setattr(transcription, "transcription_engine", "faster-whisper")
-    monkeypatch.setattr(transcription, "batched", False)
-    monkeypatch.setattr(transcription, "language", "en")
-    monkeypatch.setattr(
-        transcription,
-        "AudioSegment",
-        types.SimpleNamespace(from_wav=lambda p: object()),
-    )
-    monkeypatch.setattr(
-        transcription, "extract_audio_features", lambda *a, **k: _fake_audio_features()
-    )
-
-    model = _FakeModel()
-    transcription.transcribe_with_features(model, "audio.wav", "cpu", min_duration=999)
-
-    assert len(model.calls) == 1
-    assert "batch_size" not in model.calls[0]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional **batched inference** for the `faster-whisper` transcription engine, a feature introduced in faster-whisper 1.1. Batched inference decodes multiple audio chunks per pass via `BatchedInferencePipeline`, which is significantly faster than sequential decoding — especially on GPU.

## Changes

- `src/transcription.py`
  - Import `BatchedInferencePipeline` alongside `WhisperModel`.
  - Read two new settings: `batched` (bool, default `false`) and `batch_size` (int, default `8`).
  - New `build_faster_whisper_model(device)` helper that wraps the model in a `BatchedInferencePipeline` when batching is enabled.
  - `transcribe_with_features` now passes `batch_size` to `transcribe()` on the batched path, and is unchanged on the sequential path.
- `config.ini` — documents and enables the new `[clipception.transcription]` options (`batched = true`, `batch_size = 8`).
- `README.md` — documents the feature.
- `tests/test_transcription.py` — new tests covering the plumbing.

## Config

```ini
[clipception.transcription]
engine = faster-whisper
batched = true
batch_size = 8
```

Increase `batch_size` to trade GPU memory for more throughput. When `batched = false`, behavior is identical to before.

## Testing

Full suite: **92 passed** (4 new tests), verified in both collection orderings. `flake8` (E9,F63,F7,F82) 0 errors; `black --check` clean.

Real end-to-end run on an 11s JFK speech clip with the `base` model (CPU on this VM; the batched code path is identical for GPU):

- Batched (`batched = true`): builder returns `BatchedInferencePipeline`, log shows `Enabling batched inference pipeline (batch_size=8)`, transcript → *"And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country."*
- Non-batched (`batched = false`): builder returns `WhisperModel`, same transcript — confirming no regression.

Note: the new tests import the real `transcription` module and drop any `sys.modules` stub first, so they're robust to `test_processor.py`'s lightweight `transcription` stub regardless of collection order.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abc81fe2-f3e9-47b7-886d-514f92c9808b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abc81fe2-f3e9-47b7-886d-514f92c9808b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

