### PR TITLE
build(deps): pin faster-whisper to latest (>=1.2.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "numpy<2.4",
   "openai>=2.21.0",
   "openai-whisper",
-  "faster-whisper",
+  "faster-whisper>=1.2.1",
   "yt-dlp>=2026.2.21",
   "requests>=2.32.0",
   "python-dotenv>=1.2.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `faster-whisper` to the latest release. The dependency was previously unconstrained in `pyproject.toml`; it's now pinned to `>=1.2.1` (the current latest, released 2025-10-31), matching the repo's `>=` versioning convention and guaranteeing a modern baseline (also satisfies the 1.1+ requirement for batched inference).

## Change

`pyproject.toml`:

```diff
-  "faster-whisper",
+  "faster-whisper>=1.2.1",
```

## Validation

- Confirmed 1.2.1 is the latest via PyPI's live API.
- Dependency resolution: `Resolved 104 packages` with `+ faster-whisper==1.2.1`, no conflicts (notably fine alongside `numpy<2.4`, `torch`, etc.).
- `pytest`: 88 passed.
- `black --check`: clean. `flake8` (E9,F63,F7,F82): 0 errors.
- Real transcription smoke test (JFK 11s clip, `base` model, CPU) produced the correct transcript, confirming the upgrade doesn't break the pipeline.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abc81fe2-f3e9-47b7-886d-514f92c9808b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abc81fe2-f3e9-47b7-886d-514f92c9808b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

